### PR TITLE
feat: split cache export, vendor security workflow, multi-runtime support

### DIFF
--- a/.github/workflows/secrets-and-sast-vendored.yml
+++ b/.github/workflows/secrets-and-sast-vendored.yml
@@ -1,0 +1,450 @@
+# ============================================================================
+# Secrets & SAST Scanning — VENDORED from eSolia/devkit
+# ============================================================================
+# Source: https://github.com/eSolia/devkit/blob/main/.github/workflows/secrets-and-sast.yml
+# Vendored: 2026-04-29
+#
+# Why vendored: eSolia/devkit is a private repo and GitHub blocks cross-org
+# `uses:` calls to private reusable workflows. RickCogley/* repos cannot call
+# eSolia/devkit's reusable workflows directly, so we keep a local copy here
+# (matching the pattern used in RickCogley/pub-cogley).
+#
+# Drift policy: re-sync periodically by diffing against the upstream file. No
+# automated sync — tedasuke is intentionally not a devkit sync consumer.
+#
+# Triggered by: .github/workflows/security.yml (the wrapper).
+#
+# Scanners:
+#   - Trivy filesystem vuln/secret/license scan
+#   - Gitleaks secret scan
+#   - Semgrep SAST (multi-language)
+#   - Syft SBOM (optional — Syft auto-detects ecosystems)
+#   - collect-scan-results bridge → scan-results artifact
+#   - security-summary
+# ============================================================================
+
+name: Secrets and SAST
+
+on:
+  workflow_call:
+    inputs:
+      source-paths:
+        description: "Space-separated paths for Semgrep to scan"
+        required: false
+        type: string
+        default: "."
+      semgrep-config:
+        description: "Semgrep rule configurations (space-separated)"
+        required: false
+        type: string
+        default: "p/owasp-top-ten p/secrets p/security-audit"
+      run-sbom:
+        description: "Run Syft SBOM generation (Syft auto-detects ecosystems)"
+        required: false
+        type: boolean
+        default: true
+      upload-sarif:
+        description: "Upload SARIF to GitHub Security tab (requires Code Security enabled, paid for private repos)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SEMGREP_APP_TOKEN:
+        description: "Optional Semgrep App token for enhanced rules"
+        required: false
+
+# Cancel in-flight scans when a new commit arrives on the same PR ref.
+# Push/release events keep running so evidence always completes for
+# merged commits and tagged releases.
+concurrency:
+  group: secrets-and-sast-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# NOTE: Per-job permissions blocks are intentionally omitted.
+# GitHub Actions does not support per-job permissions in reusable workflows
+# called via workflow_call — they cause startup_failure. The caller's
+# permissions (org default: read) apply to all jobs.
+
+jobs:
+  # ==========================================================================
+  # Trivy — filesystem vuln/secret/license scan
+  # ==========================================================================
+  trivy:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Compute weekly cache key
+        id: week
+        run: echo "key=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Trivy vulnerability database
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-v1-${{ steps.week.outputs.key }}
+          restore-keys: |
+            trivy-db-v1-
+
+      - name: Prepare reports directory
+        run: mkdir -p reports
+
+      - name: Trivy filesystem scan — vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          format: json
+          output: reports/trivy-vulns.json
+          exit-code: "0"
+        continue-on-error: true
+
+      - name: Trivy filesystem scan — secrets
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scanners: secret
+          format: json
+          output: reports/trivy-secrets.json
+          exit-code: "0"
+          skip-setup-trivy: true
+        continue-on-error: true
+
+      - name: Trivy filesystem scan — licenses
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scanners: license
+          format: json
+          output: reports/trivy-licenses.json
+          exit-code: "0"
+          skip-setup-trivy: true
+        continue-on-error: true
+
+      - name: Trivy filesystem scan — table summary
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          format: table
+          exit-code: "0"
+          skip-setup-trivy: true
+        continue-on-error: true
+
+      - name: Upload Trivy reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: trivy-reports
+          path: reports/trivy-*.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Trivy Summary
+        if: always()
+        run: |
+          echo "## Trivy Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f "reports/trivy-vulns.json" ]; then
+            CRITICAL=$(cat reports/trivy-vulns.json | jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' 2>/dev/null || echo "0")
+            HIGH=$(cat reports/trivy-vulns.json | jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' 2>/dev/null || echo "0")
+            echo "### Vulnerabilities" >> $GITHUB_STEP_SUMMARY
+            echo "- Critical: $CRITICAL" >> $GITHUB_STEP_SUMMARY
+            echo "- High: $HIGH" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ -f "reports/trivy-secrets.json" ]; then
+            SECRETS=$(cat reports/trivy-secrets.json | jq '[.Results[]?.Secrets[]?] | length' 2>/dev/null || echo "0")
+            echo "### Secrets" >> $GITHUB_STEP_SUMMARY
+            echo "- Found: $SECRETS" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "See artifacts for full details." >> $GITHUB_STEP_SUMMARY
+
+  # ==========================================================================
+  # Gitleaks secret scan
+  # ==========================================================================
+  secret-scan:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION="8.21.2"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz
+          chmod +x gitleaks
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run Gitleaks
+        run: |
+          mkdir -p reports
+          gitleaks detect --source . --report-path reports/gitleaks.json --report-format json || true
+          gitleaks detect --source . --report-path reports/gitleaks.sarif --report-format sarif || true
+        continue-on-error: true
+
+      - name: Upload Gitleaks report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gitleaks-report
+          path: reports/gitleaks.*
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Gitleaks Summary
+        if: always()
+        run: |
+          echo "## Secret Scanning Results" >> $GITHUB_STEP_SUMMARY
+          if [ -f "reports/gitleaks.json" ]; then
+            FINDINGS=$(cat reports/gitleaks.json | jq 'length' 2>/dev/null || echo "0")
+            if [ "$FINDINGS" = "0" ] || [ "$FINDINGS" = "null" ]; then
+              echo "No secrets detected" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "**$FINDINGS** potential secrets found" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "No secrets detected" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ==========================================================================
+  # Semgrep SAST
+  # ==========================================================================
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Semgrep
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_CONFIG: ${{ inputs.semgrep-config }}
+          SCAN_PATHS: ${{ inputs.source-paths }}
+        run: |
+          mkdir -p reports
+
+          CONFIG_ARGS=""
+          for config in $SEMGREP_CONFIG; do
+            CONFIG_ARGS="$CONFIG_ARGS --config $config"
+          done
+
+          # Single scan pass — SARIF is derived below via jq to avoid
+          # scanning the codebase twice.
+          semgrep scan \
+            $CONFIG_ARGS \
+            --json \
+            --output reports/semgrep.json \
+            $SCAN_PATHS \
+            || true
+        continue-on-error: true
+
+      - name: Derive SARIF from Semgrep JSON
+        run: |
+          if [ ! -f reports/semgrep.json ]; then
+            echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"semgrep"}},"results":[]}]}' > reports/semgrep.sarif
+            exit 0
+          fi
+          jq '{
+            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+            version: "2.1.0",
+            runs: [{
+              tool: {driver: {name: "semgrep", informationUri: "https://semgrep.dev"}},
+              results: [(.results // [])[] | {
+                ruleId: .check_id,
+                level: (
+                  if (.extra.severity // "INFO") == "ERROR" then "error"
+                  elif (.extra.severity // "INFO") == "WARNING" then "warning"
+                  else "note" end
+                ),
+                message: {text: (.extra.message // .check_id)},
+                locations: [{
+                  physicalLocation: {
+                    artifactLocation: {uri: .path},
+                    region: {startLine: (.start.line // 1)}
+                  }
+                }]
+              }]
+            }]
+          }' reports/semgrep.json > reports/semgrep.sarif
+
+      - name: Upload Semgrep reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-report
+          path: reports/semgrep.*
+          retention-days: 30
+
+      - name: Upload to GitHub Security
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        if: inputs.upload-sarif
+        with:
+          sarif_file: reports/semgrep.sarif
+
+      - name: Semgrep Summary
+        if: always()
+        run: |
+          echo "## Semgrep SAST Results" >> $GITHUB_STEP_SUMMARY
+          if [ -f reports/semgrep.json ]; then
+            FINDINGS=$(cat reports/semgrep.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('results', [])))" 2>/dev/null || echo "0")
+            echo "Found **$FINDINGS** potential issues" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "See uploaded artifact for details." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No report generated" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ==========================================================================
+  # SBOM Generation (Syft) — optional; Syft auto-detects ecosystems
+  # ==========================================================================
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    # SBOM runs only on non-PR events — the release-time SBOM is what
+    # ships with evidence; per-PR SBOM is noise.
+    if: inputs.run-sbom && github.event_name != 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p reports
+          syft dir:. -o cyclonedx-json="reports/sbom.cdx.json" --quiet
+          echo "SBOM size: $(wc -c < reports/sbom.cdx.json) bytes"
+          echo "Packages: $(jq '.components | length' reports/sbom.cdx.json)"
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: reports/sbom.cdx.json
+          retention-days: 90
+
+  # ==========================================================================
+  # Collect Scan Results — produces the artifact attest-and-ship.yml consumes
+  # ==========================================================================
+  collect-scan-results:
+    name: Collect Scan Results
+    runs-on: ubuntu-latest
+    needs: [trivy, secret-scan, semgrep, sbom]
+    if: always()
+    steps:
+      - name: Download all scan artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ./all-scans
+
+      - name: Aggregate into scan-results
+        run: |
+          mkdir -p scan-results
+
+          cp all-scans/gitleaks-report/gitleaks.sarif scan-results/ 2>/dev/null || true
+          cp all-scans/semgrep-report/semgrep.sarif   scan-results/ 2>/dev/null || true
+
+          cp all-scans/gitleaks-report/gitleaks.json scan-results/ 2>/dev/null || true
+          cp all-scans/semgrep-report/semgrep.json   scan-results/ 2>/dev/null || true
+          cp all-scans/trivy-reports/trivy-vulns.json    scan-results/ 2>/dev/null || true
+          cp all-scans/trivy-reports/trivy-secrets.json  scan-results/ 2>/dev/null || true
+          cp all-scans/trivy-reports/trivy-licenses.json scan-results/ 2>/dev/null || true
+
+          cp all-scans/sbom/sbom.cdx.json scan-results/ 2>/dev/null || true
+
+          TRIVY_JSON="all-scans/trivy-reports/trivy-vulns.json"
+          if [[ -f "$TRIVY_JSON" ]]; then
+            CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' "$TRIVY_JSON" 2>/dev/null || echo 0)
+            HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' "$TRIVY_JSON" 2>/dev/null || echo 0)
+          else
+            CRITICAL=0
+            HIGH=0
+          fi
+
+          GITLEAKS_JSON="all-scans/gitleaks-report/gitleaks.json"
+          if [[ -f "$GITLEAKS_JSON" ]]; then
+            SECRETS=$(jq 'length' "$GITLEAKS_JSON" 2>/dev/null || echo 0)
+          else
+            SECRETS=0
+          fi
+
+          SCANNERS='["trivy", "gitleaks", "semgrep"]'
+          if [[ -f "all-scans/sbom/sbom.cdx.json" ]]; then
+            SCANNERS='["trivy", "gitleaks", "semgrep", "syft"]'
+          fi
+
+          jq -n \
+            --argjson c "${CRITICAL:-0}" \
+            --argjson h "${HIGH:-0}" \
+            --argjson s "${SECRETS:-0}" \
+            --argjson scanners "$SCANNERS" \
+            '{
+              sarif_critical: $c,
+              sarif_high: $h,
+              secrets_found: $s,
+              scan_status: "completed",
+              scanners: $scanners
+            }' > scan-results/summary.json
+
+          echo "=== scan-results contents ==="
+          ls -la scan-results/
+          echo ""
+          echo "=== summary.json ==="
+          cat scan-results/summary.json
+
+      - name: Upload unified scan-results artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-results
+          path: scan-results/
+          retention-days: 90
+
+  # ==========================================================================
+  # Security Summary
+  # ==========================================================================
+  security-summary:
+    name: Security Summary
+    runs-on: ubuntu-latest
+    needs: [trivy, secret-scan, semgrep, sbom, collect-scan-results]
+    if: always()
+    steps:
+      - name: Generate Summary
+        env:
+          TRIVY_RESULT: ${{ needs.trivy.result }}
+          SECRET_RESULT: ${{ needs.secret-scan.result }}
+          SEMGREP_RESULT: ${{ needs.semgrep.result }}
+          SBOM_RESULT: ${{ needs.sbom.result }}
+          COLLECT_RESULT: ${{ needs.collect-scan-results.result }}
+        run: |
+          echo "## Security Scan Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Trivy (vulns/secrets/licenses) | $TRIVY_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gitleaks Secrets | $SECRET_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Semgrep SAST | $SEMGREP_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Syft SBOM | $SBOM_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Scan Results Aggregation | $COLLECT_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "See individual job artifacts for detailed reports." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "*Workflow vendored from [eSolia/devkit](https://github.com/eSolia/devkit) — see .github/workflows/secrets-and-sast-vendored.yml header for sync policy.*" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+# Security Scanning — wrapper that triggers the vendored secrets-and-sast workflow.
+#
+# Vendored workflow lives at .github/workflows/secrets-and-sast-vendored.yml.
+# Wrapper exists because the vendored file is `on: workflow_call` only — this
+# wrapper provides the actual triggers and forwards inputs.
+
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Sunday at 00:00 UTC
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Secrets & SAST
+    uses: ./.github/workflows/secrets-and-sast-vendored.yml
+    with:
+      source-paths: "mod.ts src"
+      run-sbom: true
+    secrets:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,30 +3,54 @@
 ## Overview
 
 TeDasuke (手助け - "helping hand") is a fluent, type-safe TypeScript library for
-the Foresoft TeamDesk (aka dbFLEX) REST API, designed to be published on JSR.
+the Foresoft TeamDesk (aka dbFLEX) REST API, published on JSR.
+
+## Runtime portability
+
+The package has two entry points:
+
+- `@rick/tedasuke` — main entry. `fetch()` and Web APIs only. Runs on Deno, Node
+  ≥ 18, Bun, and Cloudflare Workers. Browsers work in principle but TeamDesk's
+  REST API typically blocks CORS.
+- `@rick/tedasuke/cache` — Deno-only filesystem cache for build resilience (used
+  by Lume / static-site generators). Uses `Deno.mkdir`, `Deno.writeTextFile`,
+  etc. — would throw `ReferenceError: Deno is not
+  defined` on other runtimes.
+
+The cache module is **not re-exported** from the main entry, so non-Deno
+consumers can use the client without the bundler ever pulling in the FS code.
+When adding new code to `src/`:
+
+- New runtime-agnostic features → re-export from `mod.ts`.
+- New Deno-specific features → add a sibling file under `src/` and create a new
+  export entry in `deno.json` (e.g. `"./fs": "./src/fs.ts"`).
 
 ## Project Structure
 
 ```
 tedasuke/
-├── mod.ts                   # Main entry point (exports all public APIs)
-├── deno.json               # Deno + JSR configuration (single source of truth)
+├── mod.ts                   # Main entry — runtime-agnostic exports
+├── deno.json               # Deno + JSR configuration; declares two entries:
+│                           #   "."      → ./mod.ts        (universal)
+│                           #   "./cache" → ./src/cache.ts (Deno-only)
 ├── README.md               # Comprehensive documentation
 ├── CLAUDE.md               # This file - project context
 │
 ├── .github/
 │   ├── workflows/
-│   │   ├── ci.yml                    # PR/main: fmt, lint, check, test, publish dry-run
-│   │   ├── publish.yml               # Tag push (v*): publish to JSR
-│   │   └── secrets-and-sast.yml      # Calls eSolia/devkit reusable security workflow
-│   └── dependabot.yml                # Weekly github-actions updates
+│   │   ├── ci.yml                       # PR/main: fmt, lint, check, test, publish dry-run
+│   │   ├── publish.yml                  # Tag push (v*): publish to JSR
+│   │   ├── security.yml                 # Wrapper triggering secrets-and-sast-vendored.yml
+│   │   └── secrets-and-sast-vendored.yml # Vendored from eSolia/devkit (private repo;
+│   │                                     # cross-org reusable workflow blocked, so vendored)
+│   └── dependabot.yml                   # Weekly github-actions updates
 │
 ├── .claude/
 │   └── rules/
 │       └── change-management.md      # ISO 27001 issue-branch-PR-merge-verify workflow
 │
 ├── src/
-│   ├── cache.ts          # fetchWithCache fallback for build resilience
+│   ├── cache.ts          # Deno-only — exposed as @rick/tedasuke/cache
 │   ├── client.ts          # TeamDeskClient - main API client
 │   ├── table.ts           # TableClient, ViewClient, SelectBuilder
 │   ├── types.ts           # TypeScript type definitions

--- a/README.md
+++ b/README.md
@@ -9,21 +9,56 @@ this library provides for working with the TeamDesk API.
 
 - 🎯 **Fluent API** - Chainable methods that read like English
 - 🔒 **Type-safe** - Full TypeScript support with generic types
-- 🚀 **Modern** - Built for Deno with Node.js compatibility via JSR
-- 📦 **Zero dependencies** - Uses native Deno/Web APIs
+- 🌐 **Multi-runtime** - Runs on Deno, Node.js (≥18), Bun, and Cloudflare
+  Workers using only `fetch()` and standard Web APIs
+- 📦 **Zero dependencies** - No third-party packages
 - 🎨 **Intuitive** - Simple things are simple, complex things are possible
 - 🔄 **Auto-pagination** - Built-in support for fetching large datasets
 - ✨ **Clean errors** - Rich error context for debugging
+- 💾 **Optional Deno-only filesystem cache** - For build resilience in
+  static-site generators (separate import — non-Deno consumers don't pull it in)
+
+## Runtime compatibility
+
+| Runtime            | Main entry (`@rick/tedasuke`)                      | Filesystem cache (`@rick/tedasuke/cache`) |
+| ------------------ | -------------------------------------------------- | ----------------------------------------- |
+| Deno               | ✅                                                 | ✅                                        |
+| Node.js ≥ 18       | ✅                                                 | ❌ (uses `Deno.*` FS APIs)                |
+| Bun                | ✅                                                 | ❌                                        |
+| Cloudflare Workers | ✅                                                 | ❌ (no filesystem)                        |
+| Browsers           | ⚠️ TeamDesk REST API typically does not allow CORS | ❌                                        |
+
+The main entry uses only `fetch()` and standard Web APIs. The cache module is
+deliberately a separate import so non-Deno consumers don't pull in any
+Deno-specific code.
 
 ## Installation
 
 ### Deno
 
-```typescript
-import { TeamDeskClient } from "jsr:@rick/tedasuke";
+```bash
+deno add jsr:@rick/tedasuke
+# Optional Deno-only filesystem cache:
+deno add jsr:@rick/tedasuke/cache
 ```
 
-### Node.js (via JSR)
+```typescript
+import { TeamDeskClient } from "@rick/tedasuke";
+```
+
+### Node.js / Bun (via JSR)
+
+```bash
+npx jsr add @rick/tedasuke
+# or
+bunx jsr add @rick/tedasuke
+```
+
+```typescript
+import { TeamDeskClient } from "@rick/tedasuke";
+```
+
+### Cloudflare Workers
 
 ```bash
 npx jsr add @rick/tedasuke
@@ -31,12 +66,24 @@ npx jsr add @rick/tedasuke
 
 ```typescript
 import { TeamDeskClient } from "@rick/tedasuke";
+
+export default {
+  async fetch(_req, env) {
+    const client = new TeamDeskClient({
+      appId: 12345,
+      token: env.TD_TOKEN,
+      useBearerAuth: true,
+    });
+    const orders = await client.table("Orders").select().limit(50).execute();
+    return Response.json(orders);
+  },
+};
 ```
 
 ## Quick Start
 
 ```typescript
-import { TeamDeskClient } from "jsr:@rick/tedasuke";
+import { TeamDeskClient } from "@rick/tedasuke";
 
 // Create a client (defaults to TeamDesk API)
 const client = new TeamDeskClient({
@@ -284,7 +331,7 @@ import {
   AuthenticationError,
   TeamDeskError,
   ValidationError,
-} from "jsr:@rick/tedasuke";
+} from "@rick/tedasuke";
 
 try {
   const data = await client
@@ -305,17 +352,23 @@ try {
 }
 ```
 
-### Cache Fallback (Build Resilience)
+### Cache Fallback (Build Resilience, Deno only)
 
-TeDasuke includes automatic caching to disk for build resilience. **Caching is
-enabled by default** and falls back to cached data when the API is unavailable.
+The optional `@rick/tedasuke/cache` entry provides a filesystem cache that falls
+back to the last-known-good data when the API is briefly unavailable. It uses
+`Deno.*` filesystem APIs and **only works on Deno** (typical use: Lume /
+static-site builds).
 
-**Default behavior:**
+The `cacheDir` option on `TeamDeskClient` simply records the path the client
+should hand to the cache helpers — it does not pull in any FS code on its own,
+so it's safe to set even on non-Deno runtimes (the path is just unused).
+
+**Default cache directory:**
 
 ```typescript
-import { TeamDeskClient } from "jsr:@rick/tedasuke";
+import { TeamDeskClient } from "@rick/tedasuke";
 
-// Caching is automatic - defaults to "./_tdcache" directory
+// cacheDir defaults to "./_tdcache" — only meaningful when using @rick/tedasuke/cache
 const client = new TeamDeskClient({
   appId: 12345,
   token: Deno.env.get("API_KEY")!,
@@ -328,7 +381,7 @@ const client = new TeamDeskClient({
 const client = new TeamDeskClient({
   appId: 12345,
   token: Deno.env.get("API_KEY")!,
-  cacheDir: "src/_data/_tdcache", // Custom location
+  cacheDir: "src/_data/_tdcache",
 });
 ```
 
@@ -338,22 +391,22 @@ const client = new TeamDeskClient({
 const client = new TeamDeskClient({
   appId: 12345,
   token: Deno.env.get("API_KEY")!,
-  cacheDir: null, // or false - disables caching
+  cacheDir: null, // or false
 });
 ```
 
-**Using `fetchWithCache` helper:**
+**Using `fetchWithCache` helper (Deno only):**
 
 ```typescript
-import { fetchWithCache, TeamDeskClient } from "jsr:@rick/tedasuke";
+import { TeamDeskClient } from "@rick/tedasuke";
+import { fetchWithCache } from "@rick/tedasuke/cache";
 
 const client = new TeamDeskClient({
   appId: 12345,
   token: Deno.env.get("API_KEY")!,
-  cacheDir: "./_tdcache", // Configure once
+  cacheDir: "./_tdcache",
 });
 
-// Pass client directly - it uses the configured cache directory
 const result = await fetchWithCache(
   client,
   "orders",
@@ -378,7 +431,7 @@ Perfect for static site generation with Lume:
 
 ```typescript
 // In your _data/prodb.ts file
-import { TeamDeskClient } from "jsr:@rick/tedasuke";
+import { TeamDeskClient } from "@rick/tedasuke";
 
 const td = new TeamDeskClient({
   appId: 12345,
@@ -642,14 +695,16 @@ deno task example
 
 ## Publishing
 
-This package is published to JSR (JavaScript Registry):
+This package is published to JSR (JavaScript Registry). Releases are automated —
+`.github/workflows/publish.yml` runs on any `v*` tag push and calls
+`deno publish` with provenance via OIDC.
 
 ```bash
-# Dry run to validate
-deno task publish
+# Local dry-run to validate
+deno task publish:dry
 
-# Publish for real
-deno publish
+# Cut a release (creates the tag, pushes it, triggers publish.yml)
+gh release create v0.3.0 --notes "..."
 ```
 
 ## License

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,10 @@
 {
   "name": "@rick/tedasuke",
-  "version": "0.2.7",
-  "exports": "./mod.ts",
+  "version": "0.3.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./cache": "./src/cache.ts"
+  },
   "tasks": {
     "example": "deno run --allow-net --allow-env examples/basic-usage.ts",
     "test": "deno test --allow-net --allow-env",

--- a/mod.ts
+++ b/mod.ts
@@ -1,55 +1,72 @@
 /**
- * TeDasuke - TeamDesk TypeScript Client Library
+ * # TeDasuke — TeamDesk / DBFlex TypeScript client
  *
- * A fluent, type-safe library for interacting with the TeamDesk/DBFlex REST API.
+ * A fluent, type-safe library for the TeamDesk / DBFlex REST API.
  * "TeDasuke" (手助け) means "helping hand" in Japanese.
  *
- * Features automatic caching for build resilience - falls back to cached data
- * when the API is unavailable.
+ * ## Runtime compatibility
  *
- * @example
+ * The main entry (`@rick/tedasuke`) uses only `fetch()` and standard Web APIs —
+ * no Deno, Node, or browser-specific globals. It runs unchanged on:
+ *
+ * - **Deno** (any version)
+ * - **Node.js** ≥ 18 (native fetch)
+ * - **Bun**
+ * - **Cloudflare Workers**
+ * - **Browsers** — works in principle, but the TeamDesk REST API typically
+ *   does not allow CORS, so practical use from a browser is rare
+ *
+ * The optional filesystem cache for build resilience lives in a separate
+ * Deno-only entry: `@rick/tedasuke/cache`. It is not re-exported from this
+ * module — Workers/Node/Bun consumers don't even import the Deno FS code.
+ *
+ * ## Installation
+ *
+ * ```bash
+ * # Deno
+ * deno add jsr:@rick/tedasuke
+ *
+ * # Node.js / Bun
+ * npx jsr add @rick/tedasuke
+ * # or
+ * bunx jsr add @rick/tedasuke
+ * ```
+ *
+ * ## Quick start
+ *
  * ```typescript
- * import { TeamDeskClient, fetchWithCache } from "jsr:@rick/tedasuke";
+ * import { TeamDeskClient } from "@rick/tedasuke";
  *
- * // Full configuration options
  * const client = new TeamDeskClient({
  *   appId: 12345,
- *   token: Deno.env.get("TD_TOKEN")!,
- *   // defaults to https://www.teamdesk.net/secure/api/v2
- *   // override for DBFlex or custom domains
- *   baseUrl: "https://my.dbflex.net/secure/api/v2",
- *   cacheDir: "./_tdcache", // optional, defaults to "./_tdcache", set to null to disable
- *   debug: false, // optional
- *   useBearerAuth: true // optional, sends token as "Authorization: Bearer" header (recommended for security)
+ *   token: "your-api-token",
+ *   useBearerAuth: true, // recommended — keeps token out of URL
  * });
  *
- * // Simple query
  * const orders = await client
- *   .table('Orders')
- *   .select()
- *   .execute();
- *
- * // With filtering and sorting
- * const activeOrders = await client
- *   .table('Orders')
- *   .select(['OrderID', 'Total', 'CustomerName'])
+ *   .table("Orders")
+ *   .select(["OrderID", "Total", "CustomerName"])
  *   .filter('[Status]="Active"')
- *   .sort('OrderDate', 'DESC')
+ *   .sort("OrderDate", "DESC")
  *   .limit(100)
  *   .execute();
+ * ```
  *
- * // Using a view
- * const data = await client
- *   .table('Orders')
- *   .view('Active Orders')
- *   .select()
- *   .execute();
+ * ## Filesystem cache (Deno only)
  *
- * // Cache fallback for build resilience
+ * For static-site generators and other Deno workflows that need build-time
+ * resilience when the API is briefly unavailable:
+ *
+ * ```typescript
+ * import { TeamDeskClient } from "@rick/tedasuke";
+ * import { fetchWithCache } from "@rick/tedasuke/cache";
+ *
+ * const client = new TeamDeskClient({ appId: 12345, token: "..." });
+ *
  * const result = await fetchWithCache(
  *   client,
  *   "orders",
- *   () => client.table('Orders').select().execute()
+ *   () => client.table("Orders").select().execute(),
  * );
  *
  * if (result.fromCache) {
@@ -60,13 +77,13 @@
  * @module
  */
 
-// Export main client
+// Main client
 export { TeamDeskClient } from "./src/client.ts";
 
-// Export table and view clients
+// Table and view clients
 export { TableClient, ViewClient } from "./src/table.ts";
 
-// Export error classes
+// Error classes
 export {
   AuthenticationError,
   NotFoundError,
@@ -76,16 +93,7 @@ export {
   ValidationError,
 } from "./src/errors.ts";
 
-// Export cache utilities
-export {
-  clearCache,
-  fetchWithCache,
-  getCacheInfo,
-  loadFromCache,
-  saveToCache,
-} from "./src/cache.ts";
-
-// Export types
+// Types
 export type {
   ApiError,
   ColumnSchema,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,45 @@
 /**
- * TeDasuke - Cache utilities
- * Helper functions for caching API responses to disk
+ * # TeDasuke — Filesystem cache (Deno only)
+ *
+ * Helpers that persist API responses to disk so static-site builds can fall
+ * back to the last-known-good data when the API is temporarily unavailable.
+ *
+ * ## Runtime
+ *
+ * **Deno only.** All functions in this module use `Deno.mkdir`,
+ * `Deno.writeTextFile`, `Deno.readTextFile`, `Deno.stat`, and `Deno.remove`.
+ * They will throw `ReferenceError: Deno is not defined` on Node, Bun,
+ * Cloudflare Workers, and in browsers.
+ *
+ * The main `@rick/tedasuke` entry deliberately does not re-export from here,
+ * so non-Deno consumers can use the client without ever pulling in this file.
+ *
+ * ## Installation
+ *
+ * ```bash
+ * deno add jsr:@rick/tedasuke jsr:@rick/tedasuke/cache
+ * ```
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { TeamDeskClient } from "@rick/tedasuke";
+ * import { fetchWithCache } from "@rick/tedasuke/cache";
+ *
+ * const client = new TeamDeskClient({
+ *   appId: 12345,
+ *   token: Deno.env.get("TD_TOKEN")!,
+ *   cacheDir: "./_tdcache",
+ * });
+ *
+ * const result = await fetchWithCache(
+ *   client,
+ *   "orders",
+ *   () => client.table("Orders").select().execute(),
+ * );
+ * ```
+ *
+ * @module
  */
 
 import type { TeamDeskClient } from "./client.ts";

--- a/tests/api_surface_test.ts
+++ b/tests/api_surface_test.ts
@@ -1,13 +1,8 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@1";
 import {
   AuthenticationError,
-  clearCache,
-  fetchWithCache,
-  getCacheInfo,
-  loadFromCache,
   NotFoundError,
   RateLimitError,
-  saveToCache,
   ServerError,
   TableClient,
   TeamDeskClient,
@@ -15,6 +10,13 @@ import {
   ValidationError,
   ViewClient,
 } from "../mod.ts";
+import {
+  clearCache,
+  fetchWithCache,
+  getCacheInfo,
+  loadFromCache,
+  saveToCache,
+} from "../src/cache.ts";
 
 Deno.test("public API surface — main entry exports are present", () => {
   assertExists(TeamDeskClient);
@@ -26,10 +28,26 @@ Deno.test("public API surface — main entry exports are present", () => {
   assertExists(RateLimitError);
   assertExists(ServerError);
   assertExists(ValidationError);
+});
+
+Deno.test("public API surface — main entry does NOT export cache helpers", async () => {
+  const main = await import("../mod.ts");
+  assertEquals(
+    "fetchWithCache" in main,
+    false,
+    "fetchWithCache must live in @rick/tedasuke/cache, not the main entry",
+  );
+  assertEquals("saveToCache" in main, false);
+  assertEquals("loadFromCache" in main, false);
+  assertEquals("getCacheInfo" in main, false);
+  assertEquals("clearCache" in main, false);
+});
+
+Deno.test("cache entry — exports are present", () => {
   assertExists(fetchWithCache);
-  assertExists(getCacheInfo);
   assertExists(saveToCache);
   assertExists(loadFromCache);
+  assertExists(getCacheInfo);
   assertExists(clearCache);
 });
 


### PR DESCRIPTION
## Summary

Two changes in one PR per discussion:

1. **Runtime portability** — split the Deno-only filesystem cache into a separate JSR export so the main `@rick/tedasuke` entry runs on Deno, Node ≥ 18, Bun, and Cloudflare Workers using only `fetch()` and standard Web APIs.
2. **Vendor the security workflow** — `secrets-and-sast.yml` is now a local copy of devkit's reusable workflow (not a cross-org `uses:`), matching the pattern already used in `RickCogley/pub-cogley`. This unblocks #3.

Closes #3.

## What changed

### Two-entry export

| Entry                    | File           | Runtime                        |
| ------------------------ | -------------- | ------------------------------ |
| `@rick/tedasuke`         | `mod.ts`       | Deno / Node ≥ 18 / Bun / Workers / Browsers (CORS caveat) |
| `@rick/tedasuke/cache`   | `src/cache.ts` | Deno only — uses `Deno.*` FS APIs |

`mod.ts` no longer re-exports any cache helpers. JSR's "Use with" sidebar will reflect both runtimes once you mark compat in the JSR settings.

### Module-level JSDoc

Both `mod.ts` and `src/cache.ts` now have `@module` blocks with runtime info, install commands per runtime, and quick-start examples. JSR's Overview tab is generated from these.

### Test coverage

The smoke test now asserts the export contract in both directions — main entry must NOT contain cache helpers, cache entry must contain them. Two new tests, total 6 passing.

### Vendored workflow

| File | Role |
|------|------|
| `.github/workflows/secrets-and-sast-vendored.yml` | 451-line copy of devkit's workflow as of 2026-04-29. Header documents source URL, sync date, drift policy. |
| `.github/workflows/security.yml`                  | Wrapper that triggers on push/PR/weekly cron/dispatch and forwards inputs to the vendored workflow_call. |

No new secrets needed — `SEMGREP_APP_TOKEN` is optional upstream and tedasuke runs free Semgrep rules.

### Version bump

`0.2.7 → 0.3.0` because removing cache helpers from the main entry is a breaking change (anyone currently doing `import { fetchWithCache } from "@rick/tedasuke"` will need to update to `from "@rick/tedasuke/cache"`). JSR shows ~17 weekly downloads with one known consumer, so the blast radius is small.

## After merge

The JSR settings → Runtime Compat checkboxes can be set to:

- Deno: ✅ Supported
- Node.js: ✅ Supported
- Bun: ✅ Supported
- Cloudflare Workers: ✅ Supported
- Browsers: ⚠️ Compatibility unknown (CORS caveat — note in description)

Then `gh release create v0.3.0` will trigger `publish.yml` and the new version will appear on JSR.

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check **/*.ts` passes
- [x] `deno test --allow-net --allow-env` — 6 passed, 0 failed (incl. new export-contract assertions)
- [x] `deno publish --dry-run` succeeds — bundle includes both `mod.ts` and `src/cache.ts`, version 0.3.0
- [ ] CI workflow runs green on this PR
- [ ] **Security workflow runs green on this PR** (this is the moment the vendor approach gets validated end-to-end — first time SAST/secret scanning actually runs in tedasuke)

InfoSec: brings continuous SAST + secret scanning + SBOM to tedasuke, which previously had zero security automation. Vendoring chosen over cross-org reusable workflow because eSolia/devkit is private (per #3 analysis).
